### PR TITLE
point to the right context path

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -12,4 +12,4 @@ deploy:
   project-org: thoth-station
   project-name: thoth-application
   image-name: investigator
-  overlay-contextpath: core/overlays/test/imagestreamtag.yaml
+  overlay-contextpath: core/overlays/test/imagestreamtags.yaml


### PR DESCRIPTION
point to the right context path
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/thoth-application/issues/120

## This introduces a breaking change

- [x] No

## This Pull Request implements

context path should be pointing to this https://github.com/thoth-station/thoth-application/blob/master/core/overlays/test/imagestreamtags.yaml manifest file, so ci can update on release.