### PR TITLE
Remove SI scheduling from UnresolvedPackageMessage

### DIFF
--- a/consumer.py
+++ b/consumer.py
@@ -28,11 +28,11 @@ from thoth.messaging import AdviserReRunMessage
 from thoth.messaging import HashMismatchMessage
 from thoth.messaging import MissingPackageMessage
 from thoth.messaging import MissingVersionMessage
+from thoth.messaging import PackageReleasedMessage
+from thoth.messaging import SIUnanalyzedPackageMessage
 from thoth.messaging import SolvedPackageMessage
 from thoth.messaging import UnresolvedPackageMessage
 from thoth.messaging import UnrevsolvedPackageMessage
-from thoth.messaging import SIUnanalyzedPackageMessage
-from thoth.messaging import PackageReleasedMessage
 
 
 from investigator.investigator import __service_version__
@@ -41,11 +41,11 @@ from investigator.investigator.adviser_re_run import parse_adviser_re_run_messag
 from investigator.investigator.hash_mismatch import parse_hash_mismatch
 from investigator.investigator.missing_package import parse_missing_package
 from investigator.investigator.missing_version import parse_missing_version
+from investigator.investigator.package_released import parse_package_released_message
+from investigator.investigator.si_unanalyzed_package import parse_si_unanalyzed_package_message
 from investigator.investigator.solved_package import parse_solved_package_message
 from investigator.investigator.unrevsolved_package import parse_revsolved_package_message
 from investigator.investigator.unresolved_package import parse_unresolved_package_message
-from investigator.investigator.si_unanalyzed_package import parse_si_unanalyzed_package_message
-from investigator.investigator.package_released import parse_package_released_message
 
 
 from thoth.common import OpenShift, init_logging
@@ -141,6 +141,22 @@ async def consume_missing_version(missing_versions):
         parse_missing_version(version=missing_version, openshift=openshift, graph=graph)
 
 
+@app.agent(package_released_message_topic)
+async def consume_package_released(package_releases) -> None:
+    """Loop when a package released message is received."""
+    async for package_released in package_releases:
+        parse_package_released_message(package_released=package_released, openshift=openshift, graph=graph)
+
+
+@app.agent(si_unanalyzed_package_message_topic)
+async def consume_si_unanalyzed_package(si_unanalyzed_packages) -> None:
+    """Loop when an SI Unanalyzed package message is received."""
+    async for si_unanalyzed_package in si_unanalyzed_packages:
+        parse_si_unanalyzed_package_message(
+            si_unanalyzed_package=si_unanalyzed_package, openshift=openshift, graph=graph
+        )
+
+
 @app.agent(solved_package_message_topic)
 async def consume_solved_package(solved_packages) -> None:
     """Loop when an unresolved package message is received."""
@@ -160,22 +176,6 @@ async def consume_unrevsolved_package(unrevsolved_packages) -> None:
     """Loop when an unresolved package message is received."""
     async for unrevsolved_package in unrevsolved_packages:
         parse_revsolved_package_message(unrevsolved_package=unrevsolved_package, openshift=openshift)
-
-
-@app.agent(si_unanalyzed_package_message_topic)
-async def consume_si_unanalyzed_package(si_unanalyzed_packages) -> None:
-    """Loop when an SI Unanalyzed package message is received."""
-    async for si_unanalyzed_package in si_unanalyzed_packages:
-        parse_si_unanalyzed_package_message(
-            si_unanalyzed_package=si_unanalyzed_package, openshift=openshift, graph=graph
-        )
-
-
-@app.agent(package_released_message_topic)
-async def consume_package_released(package_releases) -> None:
-    """Loop when a package released message is received."""
-    async for package_released in package_releases:
-        parse_package_released_message(package_released=package_released, openshift=openshift, graph=graph)
 
 
 if __name__ == "__main__":

--- a/investigator/investigator/unresolved_package/investigate_unresolved_package.py
+++ b/investigator/investigator/unresolved_package/investigate_unresolved_package.py
@@ -162,20 +162,8 @@ def parse_unresolved_package_message(
                 revsolver_packages_seen=revsolver_packages_seen,
             )
 
-            # SI logic
-
-            si_wfs_scheduled = common.learn_about_security(
-                openshift=openshift,
-                graph=graph,
-                is_present=is_present,
-                package_name=package_name,
-                package_version=version,
-                index_url=index_url,
-            )
-
             total_solver_wfs_scheduled += solver_wfs_scheduled
             total_revsolver_wfs_scheduled += revsolver_wfs_scheduled
-            total_si_wfs_scheduled += si_wfs_scheduled
 
     scheduled_workflows.labels(message_type=UnresolvedPackageMessage.topic_name, workflow_type="solver").inc(
         total_solver_wfs_scheduled
@@ -184,10 +172,6 @@ def parse_unresolved_package_message(
     scheduled_workflows.labels(message_type=UnresolvedPackageMessage.topic_name, workflow_type="revsolver").inc(
         total_revsolver_wfs_scheduled
     )
-
-    scheduled_workflows.labels(
-        message_type=UnresolvedPackageMessage.topic_name, workflow_type="security-indicator"
-    ).inc(total_si_wfs_scheduled)
 
     unresolved_package_success.inc()
 

--- a/investigator/investigator/unresolved_package/investigate_unresolved_package.py
+++ b/investigator/investigator/unresolved_package/investigate_unresolved_package.py
@@ -107,7 +107,6 @@ def parse_unresolved_package_message(
 
     total_solver_wfs_scheduled = 0
     total_revsolver_wfs_scheduled = 0
-    total_si_wfs_scheduled = 0
 
     # Select indexes
     registered_indexes: List[str] = graph.get_python_package_index_urls_all()


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Remove SI workflow scheduled from UnresolvedPackageMessage consumued.
We have SolvedPackageMessage and SIUnanalyzedPackageMessage that take care already.
