### PR TITLE
Correct import

### DIFF
--- a/investigator/investigator/package_extract_trigger/investigate_package_extract_trigger.py
+++ b/investigator/investigator/package_extract_trigger/investigate_package_extract_trigger.py
@@ -19,7 +19,7 @@
 
 import logging
 
-from thoth.messaging import PackageExtractMessage
+from thoth.messaging import PackageExtractTriggerMessage
 from thoth.common import OpenShift
 
 from .metrics_package_extract_trigger import package_extract_trigger_exceptions


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies
```
  File "/opt/app-root/src/consumer.py", line 51, in <module>
    from investigator.investigator.package_extract_trigger import parse_package_extract_trigger_message
  File "/opt/app-root/src/investigator/investigator/package_extract_trigger/__init__.py", line 20, in <module>
    from .investigate_package_extract_trigger import parse_package_extract_trigger_message
  File "/opt/app-root/src/investigator/investigator/package_extract_trigger/investigate_package_extract_trigger.py", line 22, in <module>
    from thoth.messaging import PackageExtractMessage
ModuleNotFoundError: No module named 'thoth-messaging'
```

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Correct wrong import
