### PR TITLE
WIP: message replay capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ to Kafka for each package release to be solved using Thoth [Solver](https://gith
 
 Consumer is currently able to handle the following Kafka messages:
 
+#### Configuration
+
+- See [thoth-messaging](https://github.com/thoth-station/messaging)
+- Faust Windowed Tables (see [here](https://faust.readthedocs.io/en/latest/userguide/tables.html))
+  - `THOTH_INVESTIGATOR_WINDOW_EXPIRATION`: Set time until message offset window expires
+  - `THOTH_INVESTIGATOR_TABLE_WINDOW`: The amount of time that a single table window covers
+- `THOTH_GITHUB_PRIVATE_TOKEN`: token for authenticating actions on GitHub repositories
+- `THOTH_GITLAB_PRIVATE_TOKEN`: token for authenticating actions on GitLab repositories
+
 #### UnresolvedPackageMessage
 
 - [UnresolvedPackageMessage](https://github.com/thoth-station/messaging/blob/master/thoth/messaging/unresolved_package.py).

--- a/consumer.py
+++ b/consumer.py
@@ -21,8 +21,11 @@
 
 import logging
 import os
+from time import time
+from datetime import timedelta
 
 from thoth.messaging import MessageBase
+
 from thoth.messaging import AdviseJustificationMessage
 from thoth.messaging import AdviserReRunMessage
 from thoth.messaging import AdviserTriggerMessage
@@ -63,6 +66,9 @@ from thoth.storages.graph import GraphDatabase
 from aiohttp import web
 from prometheus_client import generate_latest
 
+from faust import Topic
+from faust.types.tuples import TP
+
 # set up logging
 DEBUG_LEVEL = bool(int(os.getenv("DEBUG_LEVEL", 0)))
 
@@ -86,6 +92,7 @@ kebechet_trigger_message_topic = KebechetTriggerMessage().topic
 missing_package_message_topic = MissingPackageMessage().topic
 missing_version_message_topic = MissingVersionMessage().topic
 package_extract_trigger_message_topic = PackageExtractTriggerMessage().topic
+package_released_message_topic = PackageReleasedMessage().topic
 provenance_checker_trigger_message_topic = ProvenanceCheckerTriggerMessage().topic
 qebhwt_trigger_message_topic = QebHwtTriggerMessage().topic
 solved_package_message_topic = SolvedPackageMessage().topic
@@ -93,12 +100,13 @@ unresolved_package_message_topic = UnresolvedPackageMessage().topic
 unrevsolved_package_message_topic = UnrevsolvedPackageMessage().topic
 si_unanalyzed_package_message_topic = SIUnanalyzedPackageMessage().topic
 
-package_released_message_topic = PackageReleasedMessage().topic
-
 openshift = OpenShift()
 graph = GraphDatabase()
 
 graph.connect()
+
+# we should allow the time deltas to be passed as params (TEMPORARY)
+offset_table = app.Table("partition_offsets", default=int).tumbling(timedelta(minutes=1), timedelta(hours=6))
 
 
 @app.task()
@@ -120,113 +128,214 @@ async def get_health(self, request):
     return web.json_response(data)
 
 
+@app.page("/seek/{topic_name}")
+async def seek_offset(self, request, topic_name):
+    """Set offsets for a specific topic based of a time stamp."""
+    # timestamp should be passed in seconds since utc epoch
+    utc_timestamp = float(request.query["timestamp"])
+    topic = globals()[topic_name]
+    if not type(topic) == Topic:
+        raise TypeError("The passed topic is not known.")
+
+    # Get time delta from timestamp
+    delta_seconds = time() - utc_timestamp
+
+    # both of these errors should
+    if delta_seconds < 0:
+        raise ValueError("The timestamp given is from the future, I am not a fortune teller.")
+    elif timedelta(seconds=delta_seconds) > timedelta(hours=6):
+        raise Exception("Given time is beyond expiration limit.")
+
+    for p in topic.partitions:
+        # the application has a global consumer which directs and manages the streams/topics and more importantly
+        # maintains the offsets for our streams
+        await app.consumer.seek(
+            TP(topic=topic.get_topic_name(), partition=p), offset_table[(topic, p)].delta(delta_seconds),
+        )
+
+    return web.json_response({"status": "success"})
+
+
 @app.agent(advise_justification_message_topic)
-async def consume_advise_justification(advise_justifications):
+async def consume_advise_justification(stream):
     """Loop when an advise justification message is received."""
-    async for advise_justification in advise_justifications:
-        expose_advise_justification_metrics(advise_justification=advise_justification)
+    async for event in stream.events():
+        message = event.message
+        partition = message.partition
+        offset = message.offset
+        offset_table[(advise_justification_message_topic, partition)] = offset
+
+        expose_advise_justification_metrics(advise_justification=message.value)
 
 
 @app.agent(adviser_re_run_message_topic)
-async def consume_adviser_re_run(adviser_re_runs):
+async def consume_adviser_re_run(stream):
     """Loop when an adviser re run message is received."""
-    async for adviser_re_run in adviser_re_runs:
-        parse_adviser_re_run_message(adviser_re_run=adviser_re_run, openshift=openshift)
+    async for event in stream.events():
+        message = event.message
+        partition = message.partition
+        offset = message.offset
+        offset_table[(adviser_re_run_message_topic, partition)] = offset
+
+        parse_adviser_re_run_message(adviser_re_run=message.value, openshift=openshift)
 
 
 @app.agent(adviser_trigger_message_topic)
-async def consume_adviser_trigger(adviser_triggers):
+async def consume_adviser_trigger(stream):
     """Loop when an adviser trigger message is received."""
-    async for adviser_trigger in adviser_triggers:
-        parse_adviser_trigger_message(adviser_trigger=adviser_trigger, openshift=openshift)
+    async for event in stream.events():
+        message = event.message
+        partition = message.partition
+        offset = message.offset
+        offset_table[(adviser_trigger_message_topic, partition)] = offset
+
+        parse_adviser_trigger_message(adviser_trigger=message.value, openshift=openshift)
 
 
 @app.agent(hash_mismatch_message_topic)
-async def consume_hash_mismatch(hash_mismatches):
+async def consume_hash_mismatch(stream):
     """Loop when an hash mismatch message is received."""
-    async for hash_mismatch in hash_mismatches:
-        parse_hash_mismatch(mismatch=hash_mismatch, openshift=openshift, graph=graph)
+    async for event in stream.events():
+        message = event.message
+        partition = message.partition
+        offset = message.offset
+        offset_table[(hash_mismatch_message_topic, partition)] = offset
+
+        parse_hash_mismatch(mismatch=message.value, openshift=openshift, graph=graph)
 
 
 @app.agent(kebechet_trigger_message_topic)
-async def consume_kebechet_trigger(kebechet_triggers):
+async def consume_kebechet_trigger(stream):
     """Loop when a kebechet_trigger message is received."""
-    async for kebechet_trigger in kebechet_triggers:
-        parse_kebechet_trigger_message(kebechet_trigger=kebechet_trigger, openshift=openshift)
+    async for event in stream.events():
+        message = event.message
+        partition = message.partition
+        offset = message.offset
+        offset_table[(kebechet_trigger_message_topic, partition)] = offset
+
+        parse_kebechet_trigger_message(kebechet_trigger=message.value, openshift=openshift)
 
 
 @app.agent(missing_package_message_topic)
-async def consume_missing_package(missing_packages):
+async def consume_missing_package(stream):
     """Loop when an missing package message is received."""
-    async for missing_package in missing_packages:
-        parse_missing_package(package=missing_package, openshift=openshift, graph=graph)
+    async for event in stream.events():
+        message = event.message
+        partition = message.partition
+        offset = message.offset
+        offset_table[(missing_package_message_topic, partition)] = offset
+
+        parse_missing_package(package=message.value, openshift=openshift, graph=graph)
 
 
 @app.agent(missing_version_message_topic)
-async def consume_missing_version(missing_versions):
+async def consume_missing_version(stream):
     """Loop when an missing version message is received."""
-    async for missing_version in missing_versions:
-        parse_missing_version(version=missing_version, openshift=openshift, graph=graph)
+    async for event in stream.events():
+        message = event.message
+        partition = message.partition
+        offset = message.offset
+        offset_table[(missing_version_message_topic, partition)] = offset
+
+        parse_missing_version(version=message.value, openshift=openshift, graph=graph)
 
 
 @app.agent(package_extract_trigger_message_topic)
-async def consume_package_extract_trigger(package_extract_triggers):
+async def consume_package_extract_trigger(stream):
     """Loop when a package_extract_trigger message is received."""
-    async for package_extract_trigger in package_extract_triggers:
-        parse_package_extract_trigger_message(package_extract_trigger=package_extract_trigger, openshift=openshift)
+    async for event in stream.events():
+        message = event.message
+        partition = message.partition
+        offset = message.offset
+        offset_table[(package_extract_trigger_message_topic, partition)] = offset
+
+        parse_package_extract_trigger_message(package_extract_trigger=message.value, openshift=openshift)
 
 
 @app.agent(package_released_message_topic)
-async def consume_package_released(package_releases) -> None:
+async def consume_package_released(stream) -> None:
     """Loop when a package released message is received."""
-    async for package_released in package_releases:
-        parse_package_released_message(package_released=package_released, openshift=openshift, graph=graph)
+    async for event in stream.events():
+        message = event.message
+        partition = message.partition
+        offset = message.offset
+        offset_table[(package_released_message_topic, partition)] = offset
+
+        parse_package_released_message(package_released=message.value, openshift=openshift, graph=graph)
 
 
 @app.agent(provenance_checker_trigger_message_topic)
-async def consume_provenance_checker_trigger(provenance_checker_triggers):
+async def consume_provenance_checker_trigger(stream):
     """Loop when a provenance_checker_trigger message is received."""
-    async for provenance_checker_trigger in provenance_checker_triggers:
+    async for event in stream.events():
+        message = event.message
+        partition = message.partition
+        offset = message.offset
+        offset_table[(provenance_checker_trigger_message_topic, partition)] = offset
+
         parse_provenance_checker_trigger_message(
-            provenance_checker_trigger=provenance_checker_trigger, openshift=openshift,
+            provenance_checker_trigger=message.value, openshift=openshift,
         )
 
 
 @app.agent(qebhwt_trigger_message_topic)
-async def consume_qebhwt_trigger(qebhwt_triggers):
+async def consume_qebhwt_trigger(stream):
     """Loop when a qebhwt_trigger message is received."""
-    async for qebhwt_trigger in qebhwt_triggers:
-        parse_qebhwt_trigger_message(qebhwt_trigger=qebhwt_trigger, openshift=openshift)
+    async for event in stream.events():
+        message = event.message
+        partition = message.partition
+        offset = message.offset
+        offset_table[(qebhwt_trigger_message_topic, partition)] = offset
+
+        parse_qebhwt_trigger_message(qebhwt_trigger=message.value, openshift=openshift)
 
 
 @app.agent(si_unanalyzed_package_message_topic)
-async def consume_si_unanalyzed_package(si_unanalyzed_packages) -> None:
+async def consume_si_unanalyzed_package(stream) -> None:
     """Loop when an SI Unanalyzed package message is received."""
-    async for si_unanalyzed_package in si_unanalyzed_packages:
-        parse_si_unanalyzed_package_message(
-            si_unanalyzed_package=si_unanalyzed_package, openshift=openshift, graph=graph
-        )
+    async for event in stream.events():
+        message = event.message
+        partition = message.partition
+        offset = message.offset
+        offset_table[(si_unanalyzed_package_message_topic, partition)] = offset
+
+        parse_si_unanalyzed_package_message(si_unanalyzed_package=message.value, openshift=openshift, graph=graph)
 
 
 @app.agent(solved_package_message_topic)
-async def consume_solved_package(solved_packages) -> None:
+async def consume_solved_package(stream) -> None:
     """Loop when an unresolved package message is received."""
-    async for solved_package in solved_packages:
-        parse_solved_package_message(solved_package=solved_package, openshift=openshift, graph=graph)
+    async for event in stream.events():
+        message = event.message
+        partition = message.partition
+        offset = message.offset
+        offset_table[(solved_package_message_topic, partition)] = offset
+
+        parse_solved_package_message(solved_package=message.value, openshift=openshift, graph=graph)
 
 
 @app.agent(unresolved_package_message_topic)
-async def consume_unresolved_package(unresolved_packages) -> None:
+async def consume_unresolved_package(stream) -> None:
     """Loop when an unresolved package message is received."""
-    async for unresolved_package in unresolved_packages:
-        parse_unresolved_package_message(unresolved_package=unresolved_package, openshift=openshift, graph=graph)
+    async for event in stream.events():
+        message = event.message
+        partition = message.partition
+        offset = message.offset
+        offset_table[(unresolved_package_message_topic, partition)] = offset
+
+        parse_unresolved_package_message(unresolved_package=message.value, openshift=openshift, graph=graph)
 
 
 @app.agent(unrevsolved_package_message_topic)
-async def consume_unrevsolved_package(unrevsolved_packages) -> None:
+async def consume_unrevsolved_package(stream) -> None:
     """Loop when an unresolved package message is received."""
-    async for unrevsolved_package in unrevsolved_packages:
-        parse_revsolved_package_message(unrevsolved_package=unrevsolved_package, openshift=openshift)
+    async for event in stream.events():
+        message = event.message
+        partition = message.partition
+        offset = message.offset
+        offset_table[(unrevsolved_package_message_topic, partition)] = offset
+
+        parse_revsolved_package_message(unrevsolved_package=message.value, openshift=openshift)
 
 
 if __name__ == "__main__":

--- a/consumer.py
+++ b/consumer.py
@@ -105,8 +105,14 @@ graph = GraphDatabase()
 
 graph.connect()
 
+window_size = float(os.getenv("THOTH_INVESTIGATOR_TABLE_WINDOW", 1))
+window_expiration = float(os.getenv("THOTH_INVESTIGATOR_WINDOW_EXPIRATION", 12))
 # we should allow the time deltas to be passed as params (TEMPORARY)
-offset_table = app.Table("partition_offsets", default=int).tumbling(timedelta(minutes=1), timedelta(hours=6))
+offset_table = (
+    app.Table("partition_offsets", default=int)
+    .tumbling(timedelta(minutes=window_size), timedelta(hours=window_expiration))
+    .relative_to_now()
+)
 
 
 @app.task()

--- a/producer.py
+++ b/producer.py
@@ -20,10 +20,10 @@
 import logging
 import os
 
-from thoth.investigator import __service_version__
+from investigator.investigator import __service_version__
 from thoth.messaging import MessageBase
 from thoth.messaging.unresolved_package import UnresolvedPackageMessage
-from thoth.investigator.investigate_unresolved_package import investigate_unresolved_package
+from investigator.investigator.unresolved_package.investigate_unresolved_package import investigate_unresolved_package
 
 import asyncio
 


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/thoth-application/issues/421

## This introduces a breaking change

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

This will create an endpoint which allows the user to pass a topic and a epoch timestamp and the it will set the consumer offsets back to that time in order to replay the messages

## Description

Every time a message is received it's offset it committed to a tumbling table so that we have a fidelity of a minute and store these offsets for a certain number of hours. Both of these could easily be changed to be configurable so that we can adjust fidelity and the amount of time that it is stored.

The API endpoint takes a topic and a epoch timestamp and pulls the corresponding entry from the tumbling table and sets the consumer offsets so that we can replay some messages.

This beats looking at message timestamps because we can't guarantee when we consumed a message, it could have been consumed a day after it was received. In this version we make sure we don't actually jump forward instead of backwards.