### PR TITLE
Correct wrong message

### DIFF
--- a/investigator/investigator/si_unanalyzed_package/investigate_si_unanalyzed_package.py
+++ b/investigator/investigator/si_unanalyzed_package/investigate_si_unanalyzed_package.py
@@ -40,7 +40,7 @@ async def parse_si_unanalyzed_package_message(
 ) -> None:
     """Parse SI Unanalyzed package messages."""
     package_name: str = si_unanalyzed_package.package_name
-    package_version: str = si_unanalyzed_package.version
+    package_version: str = si_unanalyzed_package.package_version
     index_url: str = si_unanalyzed_package.index_url
 
     # SI logic


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

```
[2020-09-25 18:00:24,505] [1] [WARNING] Timer livelock is overlapping (interval=7.0 runtime=21.609828755001217) 
[2020-09-25 18:00:24,506] [1] [WARNING] {"name": "mode.timers", "levelname": "WARNING", "module": "timers", "lineno": 138, "funcname": "tick", "created": 1601056824.505437, "asctime": "2020-09-25 18:00:24,505", "msecs": 505.43689727783203, "relative_created": 242093.71781349182, "process": 1, "message": "Timer livelock is overlapping (interval=7.0 runtime=21.609828755001217)"} 
[2020-09-25 18:00:26,418] [1] [ERROR] [^----Agent*: [.]consume_si_unanalyzed_package]: Crashed reason=AttributeError("'MessageContents' object has no attribute 'version'",) 
```