### PR TITLE
retry on exceptions and other error handling

### DIFF
--- a/consumer.py
+++ b/consumer.py
@@ -92,8 +92,6 @@ graph.connect()
 
 running = True
 
-num_workers = int(os.getenv("THOTH_CONSUMER_WORKERS", 5))
-
 routes = web.RouteTableDef()
 
 c = None  # type: Optional[Consumer]
@@ -212,7 +210,7 @@ async def _confluent_consumer_loop(q: asyncio.Queue):
             await asyncio.sleep(0)
     finally:
         c.close()
-        for _ in range(num_workers):
+        for _ in range(Configuration.NUM_WORKERS):
             await q.put(None)  # each worker can receive this value exactly once
 
 
@@ -231,7 +229,7 @@ if __name__ == "__main__":
 
     tasks = []
     tasks.append(_confluent_consumer_loop(q=queue))
-    for _ in range(num_workers):
+    for _ in range(Configuration.NUM_WORKERS):
         tasks.append(_worker(q=queue))
 
     signal.signal(signal.SIGINT, _shutdown)

--- a/thoth/investigator/adviser_re_run/investigate_adviser_re_run.py
+++ b/thoth/investigator/adviser_re_run/investigate_adviser_re_run.py
@@ -83,6 +83,6 @@ async def _re_schedule_adviser(openshift: OpenShift, parameters: Dict[str, Any])
         is_scheduled = 1
     except Exception as e:
         _LOGGER.exception(f"Failed to schedule Adviser for `failed` adviser run {re_run_adviser_id}: {e}")
-        is_scheduled = 0
+        raise e
 
     return is_scheduled

--- a/thoth/investigator/common.py
+++ b/thoth/investigator/common.py
@@ -84,6 +84,7 @@ async def schedule_kebechet_administrator(openshift: OpenShift, message_info: di
         )
     except Exception as e:
         _LOGGER.exception(f"Failed to schedule Kebechet Administrator worflow for message type {message_name}: {e}")
+        raise e
     return workflow_id
 
 
@@ -137,7 +138,7 @@ async def _schedule_security_indicator(
         _LOGGER.exception(
             f"Failed to schedule SI for package {package_name} in version {package_version} from index {index_url}: {e}"
         )
-        is_scheduled = 0
+        raise e
 
     return is_scheduled
 
@@ -180,7 +181,7 @@ async def _schedule_revsolver(openshift: OpenShift, package_name: str, package_v
         _LOGGER.exception(
             "Failed to schedule reverse solver for %r in version %r: %r", package_name, package_version, e
         )
-        is_scheduled = 0
+        raise e
 
     return is_scheduled
 
@@ -251,7 +252,7 @@ def _schedule_solver(
         is_scheduled = 1
     except Exception as e:
         _LOGGER.exception(f"Failed to schedule solver {solver_name} for package {packages} from {indexes}: {e}")
-        is_scheduled = 0
+        raise e
 
     return is_scheduled
 
@@ -271,6 +272,6 @@ async def _schedule_all_solvers(
         are_scheduled = len(analysis_ids)
     except Exception as e:
         _LOGGER.exception(f"Failed to schedule solvers for package {packages} from {indexes}: {e}")
-        are_scheduled = 0
+        raise e
 
     return are_scheduled

--- a/thoth/investigator/configuration.py
+++ b/thoth/investigator/configuration.py
@@ -44,3 +44,8 @@ class Configuration:
     # Quota handling
     SLEEP_TIME = int(os.getenv("ARGO_PENDING_SLEEP_TIME", 2))
     PENDING_WORKFLOW_LIMIT = os.getenv("ARGO_PENDING_WORKFLOW_LIMIT", None)
+
+    # Consumer configuration
+    MAX_RETRIES = float(os.getenv("THOTH_INVESTIGATOR_MAX_RETRIES", 5))
+    BACKOFF = float(os.getenv("THOTH_INVESTIGATOR_BACKOFF", 0.5))  # Linear backoff strategy
+    ACK_ON_FAIL = bool(int(os.getenv("THOTH_INVESTIGATOR_ACK_ON_FAIL", 0)))

--- a/thoth/investigator/configuration.py
+++ b/thoth/investigator/configuration.py
@@ -49,3 +49,4 @@ class Configuration:
     MAX_RETRIES = float(os.getenv("THOTH_INVESTIGATOR_MAX_RETRIES", 5))
     BACKOFF = float(os.getenv("THOTH_INVESTIGATOR_BACKOFF", 0.5))  # Linear backoff strategy
     ACK_ON_FAIL = bool(int(os.getenv("THOTH_INVESTIGATOR_ACK_ON_FAIL", 0)))
+    NUM_WORKERS = int(os.getenv("THOTH_CONSUMER_WORKERS", 5))

--- a/thoth/investigator/configuration.py
+++ b/thoth/investigator/configuration.py
@@ -46,7 +46,7 @@ class Configuration:
     PENDING_WORKFLOW_LIMIT = os.getenv("ARGO_PENDING_WORKFLOW_LIMIT", None)
 
     # Consumer configuration
-    MAX_RETRIES = float(os.getenv("THOTH_INVESTIGATOR_MAX_RETRIES", 5))
+    MAX_RETRIES = int(os.getenv("THOTH_INVESTIGATOR_MAX_RETRIES", 5))
     BACKOFF = float(os.getenv("THOTH_INVESTIGATOR_BACKOFF", 0.5))  # Linear backoff strategy
     ACK_ON_FAIL = bool(int(os.getenv("THOTH_INVESTIGATOR_ACK_ON_FAIL", 0)))
     NUM_WORKERS = int(os.getenv("THOTH_CONSUMER_WORKERS", 5))

--- a/thoth/investigator/metrics.py
+++ b/thoth/investigator/metrics.py
@@ -66,9 +66,9 @@ scheduled_workflows = Counter(
     registry=registry,
 )
 
-subscribed_topics = Gauge(
-    "thoth_investigator_subscribed_topics",
-    "Boolean gauge indicating the subscription status of topics.",
+paused_topics = Gauge(
+    "thoth_investigator_paused_topics",
+    "Boolean gauge indicating whether consumption of the topic has been paused.",
     labelnames=["base_topic_name"],
     registry=registry,
 )

--- a/thoth/investigator/metrics.py
+++ b/thoth/investigator/metrics.py
@@ -27,32 +27,32 @@ registry = CollectorRegistry()
 
 # add the application version info metric
 investigator_info = Gauge(
-    "investigator_consumer_info", "Investigator Version Info", labelnames=["version"], registry=registry,
+    "thoth_investigator_consumer_info", "Investigator Version Info", labelnames=["version"], registry=registry,
 )
 investigator_info.labels(version=__service_version__).inc()
 
 # Metrics for Kafka
 in_progress = Gauge(
-    "investigators_in_progress",
+    "thoth_investigator_in_progress",
     "Total number of investigation messages currently being processed.",
     labelnames=["message_type"],
     registry=registry,
 )
 exceptions = Counter(
-    "investigator_exceptions",
+    "thoth_investigator_exceptions",
     "Number of investigation messages which failed to be processed.",
     labelnames=["message_type"],
     registry=registry,
 )
 success = Counter(
-    "investigators_processed",
+    "thoth_investigator_processed",
     "Number of investigation messages which were successfully processed.",
     labelnames=["message_type"],
     registry=registry,
 )
 
 failures = Counter(
-    "investigator_failures",
+    "thoth_investigator_failures",
     "Incremented when retry limit for message processing is exceeded.",
     labelnames=["message_type"],
     registry=registry,
@@ -67,7 +67,7 @@ scheduled_workflows = Counter(
 )
 
 subscribed_topics = Gauge(
-    "investigator_subscribed_topics",
+    "thoth_investigator_subscribed_topics",
     "Boolean gauge indicating the subscription status of topics.",
     labelnames=["base_topic_name"],
     registry=registry,

--- a/thoth/investigator/metrics.py
+++ b/thoth/investigator/metrics.py
@@ -51,10 +51,24 @@ success = Counter(
     registry=registry,
 )
 
+failures = Counter(
+    "investigator_failures",
+    "Incremented when retry limit for message processing is exceeded.",
+    labelnames=["message_type"],
+    registry=registry,
+)
+
 # Scheduled workflows
 scheduled_workflows = Counter(
     "thoth_investigator_scheduled_workflows",
     "Scheduled workflows by investigator per type.",
     ["message_type", "workflow_type"],
+    registry=registry,
+)
+
+subscribed_topics = Gauge(
+    "investigator_subscribed_topics",
+    "Boolean gauge indicating the subscription status of topics.",
+    labelnames=["base_topic_name"],
     registry=registry,
 )


### PR DESCRIPTION
## Related Issues and Dependencies

#312 

## This introduces a breaking change

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Errors in investigator will now have consequences. If `num_retries` is exceeded then the message is considered failed.  Based on configuration we can either ack this message and add a failure count to a prometheus metrics or treat the error with higher priority and stop consuming messages on the topic until the source of the issue has been determined (investigator unsubscribes and sets corresponding `subscribed_topic` metric to zero).

This also stops catching exceptions due to failure to schedule workflow.

New API endpoint to subscribe to topic.
