### PR TITLE
if handler hasn't been registered treat it the same as messagea excep…

### DIFF
--- a/thoth/investigator/metrics.py
+++ b/thoth/investigator/metrics.py
@@ -73,6 +73,13 @@ paused_topics = Gauge(
     registry=registry,
 )
 
+missing_handler = Gauge(
+    "thoth_investigator_missing_handler",
+    "Boolean gauge which gets set when a message version is encountered that doesn't have a registered handler.",
+    labelnames=["base_topic_name", "message_version"],
+    registry=registry,
+)
+
 schema_revision_metric = Gauge(
     "thoth_database_schema_revision_script",
     "Thoth database schema revision from script",


### PR DESCRIPTION
## Related Issues and Dependencies

Related: #462 

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

If a handler is missing right now, investigator throws an unhandled KeyError.  We should instead treat this as a failure to consume a message and use whichever strategy was specified in env vars.
