### PR TITLE
F/message metrics

### DIFF
--- a/thoth/investigator/configuration.py
+++ b/thoth/investigator/configuration.py
@@ -21,8 +21,16 @@
 
 import logging
 import os
+from enum import Enum, auto
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class ConsumerModeEnum(Enum):
+    """Class representing the different modes the consumer can use which correspond to different handler tables."""
+
+    investigator = auto()
+    metrics = auto()
 
 
 class Configuration:
@@ -52,3 +60,4 @@ class Configuration:
     BACKOFF = float(os.getenv("THOTH_INVESTIGATOR_BACKOFF", 0.5))  # Linear backoff strategy
     ACK_ON_FAIL = bool(int(os.getenv("THOTH_INVESTIGATOR_ACK_ON_FAIL", 0)))
     NUM_WORKERS = int(os.getenv("THOTH_CONSUMER_WORKERS", 5))
+    CONSUMER_MODE = os.getenv("THOTH_CONSUMER_MODE", "investigator")

--- a/thoth/investigator/inspection_completed/investigate_inspection_completed.py
+++ b/thoth/investigator/inspection_completed/investigate_inspection_completed.py
@@ -23,7 +23,7 @@ from typing import Dict, Any
 from .metrics_inspection_completed import inspection_completed_exceptions
 from .metrics_inspection_completed import inspection_completed_in_progress
 from .metrics_inspection_completed import inspection_completed_success
-from ..common import register_handler, wait_for_limit
+from ..common import register_handler, wait_for_limit, investigator_handler_table
 
 from thoth.common import OpenShift
 

--- a/thoth/investigator/metrics.py
+++ b/thoth/investigator/metrics.py
@@ -79,3 +79,13 @@ schema_revision_metric = Gauge(
     ["component", "revision", "env"],
     registry=registry,
 )
+
+
+# Message Metrics
+
+message_version_metric = Counter(
+    "message_count_by_version",
+    "Number of messages encountered by message version.",
+    ["message_type", "message_version"],
+    registry=registry,
+)


### PR DESCRIPTION
## Related Issues and Dependencies

This will create a new message consumer which can report metrics on message internals such as `message_version`

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Add a new handler table as well as a way to specify which "mode" the consumer should be in.  If we need to create a new consumer this should be extensible.

If investigator gets to large to maintain, converting this to multiple components should be pretty straight forward.
