### PR TITLE
add new args to schedule method

### DIFF
--- a/thoth/investigator/adviser_trigger/README.md
+++ b/thoth/investigator/adviser_trigger/README.md
@@ -4,6 +4,7 @@
 
 Available versions (see for message contents):
 
+- [v2](https://github.com/thoth-station/messaging/blob/ee66ba40e40d1f0a988bc5de200f5d4b09a1186a/thoth/messaging/adviser_trigger.py)
 - [Current](https://github.com/thoth-station/messaging/blob/master/thoth/messaging/adviser_trigger.py)
 
 Thoth investigator schedules the following workflow to provide advice to user (human or bot):

--- a/thoth/investigator/adviser_trigger/investigate_adviser_trigger.py
+++ b/thoth/investigator/adviser_trigger/investigate_adviser_trigger.py
@@ -34,7 +34,7 @@ from prometheus_async.aio import track_inprogress, count_exceptions
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(AdviserTriggerMessage().topic_name, ["v2"])
+@register_handler(AdviserTriggerMessage().topic_name, ["v2", "v3"])
 @count_exceptions(adviser_trigger_exceptions)
 @track_inprogress(adviser_trigger_in_progress)
 async def parse_adviser_trigger_message(adviser_trigger: Dict[str, Any], openshift: OpenShift, **kwargs) -> None:
@@ -54,6 +54,9 @@ async def parse_adviser_trigger_message(adviser_trigger: Dict[str, Any], openshi
         github_base_repo_url=adviser_trigger["github_base_repo_url"],
         re_run_adviser_id=adviser_trigger["re_run_adviser_id"],
         source_type=adviser_trigger["source_type"],
+        kebechet_metadata=adviser_trigger.get("kebechet_metadata", None),
+        justification=adviser_trigger.get("justification", None),
+        stack_info=adviser_trigger.get("stack_info", None),
     )
     _LOGGER.debug(f"Scheduled adviser workflow {workflow_id}")
     adviser_trigger_success.inc()

--- a/thoth/investigator/provenance_checker_trigger/README.md
+++ b/thoth/investigator/provenance_checker_trigger/README.md
@@ -4,6 +4,7 @@
 
 Available versions (see for message contents):
 
+- [v2](https://github.com/thoth-station/messaging/blob/ee66ba40e40d1f0a988bc5de200f5d4b09a1186a/thoth/messaging/provenance_checker_trigger.py)
 - [Current](https://github.com/thoth-station/messaging/blob/master/thoth/messaging/provenance_checker_trigger.py)
 
 Thoth investigator schedules the following workflow to provide provenance checks to user (human or bot):

--- a/thoth/investigator/provenance_checker_trigger/investigate_provenance_checker_trigger.py
+++ b/thoth/investigator/provenance_checker_trigger/investigate_provenance_checker_trigger.py
@@ -34,7 +34,7 @@ from prometheus_async.aio import track_inprogress, count_exceptions
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(ProvenanceCheckerTriggerMessage().topic_name, ["v2"])
+@register_handler(ProvenanceCheckerTriggerMessage().topic_name, ["v2", "v3"])
 @count_exceptions(provenance_checker_trigger_exceptions)
 @track_inprogress(provenance_checker_trigger_in_progress)
 async def parse_provenance_checker_trigger_message(
@@ -47,6 +47,9 @@ async def parse_provenance_checker_trigger_message(
         whitelisted_sources=provenance_checker_trigger["whitelisted_sources"],
         debug=provenance_checker_trigger["debug"],
         job_id=provenance_checker_trigger["job_id"],
+        kebechet_metadata=provenance_checker_trigger.get("kebechet_metadata", None),
+        justification=provenance_checker_trigger.get("justification", None),
+        stack_info=provenance_checker_trigger.get("stack_info", None),
     )
     _LOGGER.debug(f"Scheduled provenance checker workflow {workflow_name}")
     provenance_checker_trigger_success.inc()


### PR DESCRIPTION
## Related Issues and Dependencies

There will also be an update to messaging to create a new version of the message.  This change is not breaking. It will pass default values if it consumes "v2" of the message.

This change needs to happen before kebechet can directly send trigger messages for advise and provenance