### PR TITLE
Fix halt in consumer

### DIFF
--- a/consumer.py
+++ b/consumer.py
@@ -136,10 +136,10 @@ def _message_failed(msg):
         failures.labels(message_type=message_type).inc()
         c.commit(message=msg)
     else:
-        # halt consumption of a topic
+        # pause consumption of a topic
         for partition in c.assignment():
             if partition.topic == message_class.topic_name:
-                c.halt([partition])
+                c.pause([partition])
                 halted_partitions.append(partition)
 
         halted_topics.labels(base_topic_name=message_class.base_name).set(1)


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/investigator/issues/574

Cannot find halt() method in Consumer methods in confluend Kafka v1.7.0: https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html