### PR TITLE
add consumer offsets as metric to calculate consumer lag

### DIFF
--- a/consumer.py
+++ b/consumer.py
@@ -45,7 +45,13 @@ from thoth.investigator.common import (
     _get_class_from_base_name,
 )
 from thoth.investigator.metrics import registry
-from thoth.investigator.metrics import failures, halted_topics, schema_revision_metric, missing_handler
+from thoth.investigator.metrics import (
+    failures,
+    halted_topics,
+    schema_revision_metric,
+    missing_handler,
+    current_consumer_offset,
+)
 
 from thoth.common import OpenShift, init_logging
 from thoth.storages.graph import GraphDatabase
@@ -193,6 +199,7 @@ async def _worker(q: asyncio.Queue):
             try:
                 await func(contents, openshift=openshift, graph=graph, msg=msg)
                 c.commit(message=msg)
+                current_consumer_offset.labels(topic_name=msg.topic(), partition=msg.partition()).set(msg.offset())
                 break
             except Exception as e:
                 _LOGGER.warning(e)

--- a/thoth/investigator/metrics.py
+++ b/thoth/investigator/metrics.py
@@ -99,3 +99,10 @@ message_version_metric = Counter(
     ["message_type", "message_version"],
     registry=registry,
 )
+
+current_consumer_offset = Gauge(
+    "current_partition_offsets",
+    "Current consumer offset per partition.",
+    ["topic_name", "partition"],
+    registry=registry,
+)


### PR DESCRIPTION
## This Pull Request implements

This adds a new metric which can be used to calculate consumer offset

See: https://www.lightbend.com/blog/monitor-kafka-consumer-group-latency-with-kafka-lag-exporter

@pacospace This may be possible with the metrics already available through Strimzi

See:
https://strimzi.io/blog/2019/10/14/improving-prometheus-metrics/