### PR TITLE
Update versions in CI checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,52 +1,46 @@
 ---
 repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.10
+    rev: v1.1.13
     hooks:
       - id: remove-tabs
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.1.0
     hooks:
-      - id: trailing-whitespace
-      - id: check-merge-conflict
-      - id: end-of-file-fixer
-      - id: name-tests-test
       - id: check-added-large-files
+      - id: check-ast
       - id: check-byte-order-marker
       - id: check-case-conflict
       - id: check-docstring-first
       - id: check-json
+      - id: check-merge-conflict
       - id: check-symlinks
-      - id: detect-private-key
-      - id: check-ast
+      - id: check-toml
+      - id: check-yaml
       - id: debug-statements
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: name-tests-test
+      - id: trailing-whitespace
 
   - repo: https://github.com/pycqa/pydocstyle.git
-    rev: 6.0.0
+    rev: 6.1.1
     hooks:
       - id: pydocstyle
 
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
-    hooks:
-      - id: check-toml
-      - id: check-yaml
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
-
   - repo: https://github.com/psf/black
-    rev: 21.4b0
+    rev: 22.1.0
     hooks:
       - id: black
 
   - repo: https://github.com/tomcatling/black-nb
-    rev: "0.4.0"
+    rev: "0.7"
     hooks:
       - id: black-nb
 
   - repo: https://gitlab.com/PyCQA/flake8
-    rev: "3.9.1"
+    rev: "3.9.2"
     hooks:
       - id: flake8
         additional_dependencies: ["pep8-naming"]

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -6,7 +6,7 @@ presubmits:
     context: aicoe-ci/prow/pre-commit
     spec:
       containers:
-        - image: quay.io/thoth-station/thoth-precommit-py38:v0.12.10
+        - image: quay.io/thoth-station/thoth-precommit-py38:v0.14.3
           command:
             - "pre-commit"
             - "run"
@@ -20,7 +20,7 @@ presubmits:
     context: aicoe-ci/prow/mypy
     spec:
       containers:
-        - image: quay.io/thoth-station/thoth-pytest-ubi8-py38:v0.12.10
+        - image: quay.io/thoth-station/thoth-pytest-ubi8-py38:v0.14.3
           command:
             - "/usr/local/bin/mypy"
             - "."


### PR DESCRIPTION
## Related Issues and Dependencies

`mypy` checks are [currently failing](https://prow.operate-first.cloud/view/s3/ci-prow/prow-logs/pr-logs/pull/thoth-station_investigator/616/thoth-mypy-py38/1502402768856420352) in #616

I'm not really sure if this update will fix that, but it should not hurt either

## This introduces a breaking change

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Update the versions of the images used for prow CI checks.

Update the versions of the pre-commit checks and merge two redundant entries