### PR TITLE
break handler tablers based on namespace

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ prometheus-async = "*"
 confluent-kafka = "*"
 thoth-common = "*"
 thoth-messaging = "*"
+aenum = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2119c857dc1613272ce983b62b77aab9c16b87667449102c1c0d57ef6d5b7daa"
+            "sha256": "aa0c8d4d4488afa26c00a3c4cb5d7b8071e2a6eaadeca9c92d8d86d5fe9cd3e1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,15 @@
         ]
     },
     "default": {
+        "aenum": {
+            "hashes": [
+                "sha256:12ae89967f2e25c0ce28c293955d643f891603488bc3d9946158ba2b35203638",
+                "sha256:525b4870a27d0b471c265bda692bc657f1e0dd7597ad4186d072c59f9db666f6",
+                "sha256:aed2c273547ae72a0d5ee869719c02a643da16bf507c80958faadc7e038e3f73"
+            ],
+            "index": "pypi",
+            "version": "==3.1.11"
+        },
         "aiohttp": {
             "hashes": [
                 "sha256:02f9a2c72fc95d59b881cf38a4b2be9381b9527f9d328771e90f72ac76f31ad8",

--- a/thoth/investigator/advise_justification/investigate_advise_justification.py
+++ b/thoth/investigator/advise_justification/investigate_advise_justification.py
@@ -26,7 +26,7 @@ from .metrics_advise_justification import advise_justification_exceptions
 from .metrics_advise_justification import advise_justification_success
 from .metrics_advise_justification import advise_justification_in_progress
 from .metrics_advise_justification import advise_justification_type_number
-from ..common import register_handler
+from ..common import register_handler, metrics_handlers
 
 from thoth.messaging import advise_justification_message
 
@@ -35,7 +35,7 @@ from prometheus_async.aio import track_inprogress, count_exceptions
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(advise_justification_message.topic_name, ["v1"])
+@register_handler(advise_justification_message.topic_name, ["v1"], metrics_handlers)
 @count_exceptions(advise_justification_exceptions)
 @track_inprogress(advise_justification_in_progress)
 async def expose_advise_justification_metrics(advise_justification: Dict[str, Any], **kwargs):

--- a/thoth/investigator/adviser_trigger/investigate_adviser_trigger.py
+++ b/thoth/investigator/adviser_trigger/investigate_adviser_trigger.py
@@ -23,7 +23,7 @@ from typing import Dict, Any
 from thoth.messaging import adviser_trigger_message
 from thoth.common import OpenShift
 
-from ..common import wait_for_limit, register_handler
+from ..common import wait_for_limit, register_handler, backend_handlers
 from ..configuration import Configuration
 
 from .metrics_adviser_trigger import adviser_trigger_exceptions
@@ -34,7 +34,7 @@ from prometheus_async.aio import track_inprogress, count_exceptions
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(adviser_trigger_message.topic_name, ["v1", "v2", "v3", "v4", "v5"])
+@register_handler(adviser_trigger_message.topic_name, ["v1", "v2", "v3", "v4", "v5"], backend_handlers)
 @count_exceptions(adviser_trigger_exceptions)
 @track_inprogress(adviser_trigger_in_progress)
 async def parse_adviser_trigger_message(adviser_trigger: Dict[str, Any], openshift: OpenShift, **kwargs) -> None:

--- a/thoth/investigator/build_analysis_trigger/investigate_build_analysis_trigger.py
+++ b/thoth/investigator/build_analysis_trigger/investigate_build_analysis_trigger.py
@@ -23,7 +23,7 @@ from typing import Dict, Any
 from thoth.messaging import build_analysis_trigger_message
 from thoth.common import OpenShift
 
-from ..common import wait_for_limit, register_handler
+from ..common import wait_for_limit, register_handler, middletier_handlers
 from ..configuration import Configuration
 
 from .metrics_build_analysis_trigger import build_analysis_trigger_exceptions
@@ -34,7 +34,7 @@ from prometheus_async.aio import track_inprogress, count_exceptions
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(build_analysis_trigger_message.topic_name, ["v1"])
+@register_handler(build_analysis_trigger_message.topic_name, ["v1"], middletier_handlers)
 @count_exceptions(build_analysis_trigger_exceptions)
 @track_inprogress(build_analysis_trigger_in_progress)
 async def parse_build_analysis_trigger_message(

--- a/thoth/investigator/configuration.py
+++ b/thoth/investigator/configuration.py
@@ -22,17 +22,9 @@
 import logging
 import os
 import json
-from enum import Enum, auto
 from typing import Union
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class ConsumerModeEnum(Enum):
-    """Class representing the different modes the consumer can use which correspond to different handler tables."""
-
-    investigator = auto()
-    metrics = auto()
 
 
 def _get_ack_on_fail() -> Union[bool, list]:
@@ -43,6 +35,13 @@ def _get_ack_on_fail() -> Union[bool, list]:
         return to_ret
     else:
         raise TypeError("THOTH_INVESTIGATOR_ACK_ON_FAIL envvar must be either a integer or a list")
+
+
+def _str_to_list(s: str):
+    try:
+        return json.loads(s)
+    except ValueError:  # string is not json => represents single value
+        return [s]
 
 
 class Configuration:
@@ -72,4 +71,4 @@ class Configuration:
     BACKOFF = float(os.getenv("THOTH_INVESTIGATOR_BACKOFF", 0.5))  # Linear backoff strategy
     ACK_ON_FAIL = _get_ack_on_fail()
     NUM_WORKERS = int(os.getenv("THOTH_CONSUMER_WORKERS", 5))
-    CONSUMER_MODE = os.getenv("THOTH_CONSUMER_MODE", "investigator")
+    CONSUMER_MODES = _str_to_list(os.getenv("THOTH_CONSUMER_MODE", '["middletier", "backend"]'))

--- a/thoth/investigator/cve_provided/investigate_cve_provided.py
+++ b/thoth/investigator/cve_provided/investigate_cve_provided.py
@@ -20,7 +20,7 @@
 import logging
 from typing import Dict, Any
 
-from ..common import schedule_kebechet_administrator, register_handler
+from ..common import schedule_kebechet_administrator, register_handler, backend_handlers
 from ..configuration import Configuration
 from ..metrics import scheduled_workflows
 
@@ -34,7 +34,7 @@ from thoth.common import OpenShift
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(cve_provided_message.topic_name, ["v1"])
+@register_handler(cve_provided_message.topic_name, ["v1"], backend_handlers)
 @count_exceptions(cve_provided_exceptions)
 @track_inprogress(cve_provided_in_progress)
 async def parse_cve_provided(cve_provided: Dict[str, Any], openshift: OpenShift, **kwargs):

--- a/thoth/investigator/hash_mismatch/__init__.py
+++ b/thoth/investigator/hash_mismatch/__init__.py
@@ -17,6 +17,6 @@
 
 """The important parts for parsing hash_mismatch messages."""
 
-from .investigate_hash_mismatch import parse_hash_mismatch
+from .investigate_hash_mismatch import parse_hash_mismatch_backend, parse_hash_mismatch_middletier
 
-__all__ = ["parse_hash_mismatch"]
+__all__ = ["parse_hash_mismatch_middletier", "parse_hash_mismatch_backend"]

--- a/thoth/investigator/inspection_completed/investigate_inspection_completed.py
+++ b/thoth/investigator/inspection_completed/investigate_inspection_completed.py
@@ -25,7 +25,7 @@ from thoth.investigator.configuration import Configuration
 from .metrics_inspection_completed import inspection_completed_exceptions
 from .metrics_inspection_completed import inspection_completed_in_progress
 from .metrics_inspection_completed import inspection_completed_success
-from ..common import register_handler, wait_for_limit
+from ..common import register_handler, wait_for_limit, middletier_handlers
 
 from thoth.common import OpenShift
 
@@ -36,7 +36,7 @@ from prometheus_async.aio import track_inprogress, count_exceptions
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(inspection_completed_message.topic_name, ["v1"])
+@register_handler(inspection_completed_message.topic_name, ["v1"], middletier_handlers)
 @count_exceptions(inspection_completed_exceptions)
 @track_inprogress(inspection_completed_in_progress)
 async def parse_inspection_completed(inspection_completed: Dict[str, Any], openshift: OpenShift, **kwargs):

--- a/thoth/investigator/kebechet_run_url_trigger/investigate_kebechet_run_url_trigger.py
+++ b/thoth/investigator/kebechet_run_url_trigger/investigate_kebechet_run_url_trigger.py
@@ -23,7 +23,7 @@ from typing import Dict, Any
 from thoth.messaging import kebechet_run_url_trigger_message
 from thoth.common import OpenShift
 
-from ..common import wait_for_limit, register_handler
+from ..common import wait_for_limit, register_handler, backend_handlers
 from ..configuration import Configuration
 
 from .metrics_kebechet_run_url_trigger import kebechet_run_url_trigger_success
@@ -34,7 +34,7 @@ from prometheus_async.aio import track_inprogress, count_exceptions
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(kebechet_run_url_trigger_message.topic_name, ["v1", "v2"])
+@register_handler(kebechet_run_url_trigger_message.topic_name, ["v1", "v2"], backend_handlers)
 @count_exceptions(kebechet_run_url_trigger_exceptions)
 @track_inprogress(kebechet_run_url_trigger_in_progress)
 async def parse_kebechet_run_url_trigger_message(

--- a/thoth/investigator/kebechet_trigger/investigate_kebechet_trigger.py
+++ b/thoth/investigator/kebechet_trigger/investigate_kebechet_trigger.py
@@ -23,7 +23,7 @@ from typing import Dict, Any
 from thoth.messaging import kebechet_trigger_message
 from thoth.common import OpenShift
 
-from ..common import wait_for_limit, register_handler
+from ..common import wait_for_limit, register_handler, backend_handlers
 from ..configuration import Configuration
 
 from .metrics_kebechet_trigger import kebechet_trigger_exceptions
@@ -34,7 +34,7 @@ from prometheus_async.aio import track_inprogress, count_exceptions
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(kebechet_trigger_message.topic_name, ["v1"])
+@register_handler(kebechet_trigger_message.topic_name, ["v1"], backend_handlers)
 @count_exceptions(kebechet_trigger_exceptions)
 @track_inprogress(kebechet_trigger_in_progress)
 async def parse_kebechet_trigger_message(kebechet_trigger: Dict[str, Any], openshift: OpenShift, **kwargs) -> None:

--- a/thoth/investigator/missing_package/investigate_missing_package.py
+++ b/thoth/investigator/missing_package/investigate_missing_package.py
@@ -23,7 +23,7 @@ import logging
 from .metrics_missing_package import missing_package_exceptions
 from .metrics_missing_package import missing_package_success
 from .metrics_missing_package import missing_package_in_progress
-from ..common import register_handler, Configuration, schedule_kebechet_administrator
+from ..common import register_handler, Configuration, schedule_kebechet_administrator, backend_handlers
 
 from ..metrics import scheduled_workflows
 
@@ -35,7 +35,7 @@ from thoth.common import OpenShift
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(missing_package_message.topic_name, ["v1"])
+@register_handler(missing_package_message.topic_name, ["v1"], backend_handlers)
 @count_exceptions(missing_package_exceptions)
 @track_inprogress(missing_package_in_progress)
 async def parse_missing_package(package: Dict[str, Any], openshift: OpenShift, graph: GraphDatabase, **kwargs):

--- a/thoth/investigator/missing_version/investigate_missing_version.py
+++ b/thoth/investigator/missing_version/investigate_missing_version.py
@@ -20,7 +20,7 @@
 import logging
 from typing import Dict, Any
 
-from ..common import schedule_kebechet_administrator, register_handler
+from ..common import schedule_kebechet_administrator, register_handler, backend_handlers
 from ..metrics import scheduled_workflows
 
 from .metrics_missing_version import missing_version_exceptions
@@ -36,7 +36,7 @@ from ..configuration import Configuration
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(missing_version_message.topic_name, ["v1"])
+@register_handler(missing_version_message.topic_name, ["v1"], backend_handlers)
 @count_exceptions(missing_version_exceptions)
 @track_inprogress(missing_version_in_progress)
 async def parse_missing_version(version: Dict[str, Any], openshift: OpenShift, graph: GraphDatabase, **kwargs):

--- a/thoth/investigator/package_extract_trigger/investigate_package_extract_trigger.py
+++ b/thoth/investigator/package_extract_trigger/investigate_package_extract_trigger.py
@@ -23,7 +23,7 @@ from typing import Dict, Any
 from thoth.messaging import package_extract_trigger_message
 from thoth.common import OpenShift
 
-from ..common import wait_for_limit, register_handler
+from ..common import wait_for_limit, register_handler, backend_handlers
 from ..configuration import Configuration
 
 from .metrics_package_extract_trigger import package_extract_trigger_exceptions
@@ -34,7 +34,7 @@ from prometheus_async.aio import track_inprogress, count_exceptions
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(package_extract_trigger_message.topic_name, ["v1", "v2"])
+@register_handler(package_extract_trigger_message.topic_name, ["v1", "v2"], backend_handlers)
 @count_exceptions(package_extract_trigger_exceptions)
 @track_inprogress(package_extract_trigger_in_progress)
 async def parse_package_extract_trigger_message(

--- a/thoth/investigator/package_released/investigate_package_released.py
+++ b/thoth/investigator/package_released/investigate_package_released.py
@@ -25,7 +25,7 @@ from thoth.common import OpenShift
 
 from ..metrics import scheduled_workflows
 from .. import common
-from ..common import register_handler
+from ..common import register_handler, middletier_handlers
 from ..configuration import Configuration
 from .metrics_package_released import package_released_exceptions
 from .metrics_package_released import package_released_in_progress
@@ -33,7 +33,7 @@ from .metrics_package_released import package_released_success
 from prometheus_async.aio import track_inprogress, count_exceptions
 
 
-@register_handler(package_released_message.topic_name, ["v1"])
+@register_handler(package_released_message.topic_name, ["v1"], middletier_handlers)
 @count_exceptions(package_released_exceptions)
 @track_inprogress(package_released_in_progress)
 async def parse_package_released_message(

--- a/thoth/investigator/provenance_checker_trigger/investigate_provenance_checker_trigger.py
+++ b/thoth/investigator/provenance_checker_trigger/investigate_provenance_checker_trigger.py
@@ -23,7 +23,7 @@ from typing import Dict, Any
 from thoth.messaging import provenance_checker_trigger_message
 from thoth.common import OpenShift
 
-from ..common import wait_for_limit, register_handler
+from ..common import wait_for_limit, register_handler, backend_handlers
 from ..configuration import Configuration
 
 from .metrics_provenance_checker_trigger import provenance_checker_trigger_exceptions
@@ -34,7 +34,7 @@ from prometheus_async.aio import track_inprogress, count_exceptions
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(provenance_checker_trigger_message.topic_name, ["v1", "v2", "v3", "v4"])
+@register_handler(provenance_checker_trigger_message.topic_name, ["v1", "v2", "v3", "v4"], backend_handlers)
 @count_exceptions(provenance_checker_trigger_exceptions)
 @track_inprogress(provenance_checker_trigger_in_progress)
 async def parse_provenance_checker_trigger_message(

--- a/thoth/investigator/si_unanalyzed_package/investigate_si_unanalyzed_package.py
+++ b/thoth/investigator/si_unanalyzed_package/investigate_si_unanalyzed_package.py
@@ -28,7 +28,7 @@ from thoth.common import OpenShift
 from ..metrics import scheduled_workflows
 from .. import common
 from ..configuration import Configuration
-from ..common import register_handler
+from ..common import register_handler, middletier_handlers
 
 from .metrics_si_unanalyzed_package import si_unanalyzed_package_in_progress
 from .metrics_si_unanalyzed_package import si_unanalyzed_package_success
@@ -38,7 +38,7 @@ from prometheus_async.aio import track_inprogress, count_exceptions
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(si_unanalyzed_package_message.topic_name, ["v1"])
+@register_handler(si_unanalyzed_package_message.topic_name, ["v1"], middletier_handlers)
 @count_exceptions(si_unanalyzed_package_exceptions)
 @track_inprogress(si_unanalyzed_package_in_progress)
 async def parse_si_unanalyzed_package_message(

--- a/thoth/investigator/solved_package/investigate_solved_package.py
+++ b/thoth/investigator/solved_package/investigate_solved_package.py
@@ -27,7 +27,7 @@ from thoth.common import OpenShift
 from ..metrics import scheduled_workflows
 from .. import common
 from ..configuration import Configuration
-from ..common import register_handler
+from ..common import register_handler, middletier_handlers
 
 from .metrics_solved_package import solved_package_exceptions
 from .metrics_solved_package import solved_package_success
@@ -37,7 +37,7 @@ from prometheus_async.aio import count_exceptions, track_inprogress
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(solved_package_message.topic_name, ["v1"])
+@register_handler(solved_package_message.topic_name, ["v1"], middletier_handlers)
 @count_exceptions(solved_package_exceptions)
 @track_inprogress(solved_package_in_progress)
 async def parse_solved_package_message(

--- a/thoth/investigator/thoth_repo_init/investigate_thoth_repo_init.py
+++ b/thoth/investigator/thoth_repo_init/investigate_thoth_repo_init.py
@@ -23,7 +23,7 @@ from typing import Dict, Any
 from thoth.messaging import thoth_repo_init_message
 from thoth.common import OpenShift
 
-from ..common import wait_for_limit, register_handler
+from ..common import wait_for_limit, register_handler, backend_handlers
 from ..configuration import Configuration
 
 from .metrics_thoth_repo_init import thoth_repo_init_exceptions, thoth_repo_init_in_progress, thoth_repo_init_success
@@ -32,7 +32,7 @@ from prometheus_async.aio import track_inprogress, count_exceptions
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(thoth_repo_init_message.topic_name, ["v1"])
+@register_handler(thoth_repo_init_message.topic_name, ["v1"], backend_handlers)
 @count_exceptions(thoth_repo_init_exceptions)
 @track_inprogress(thoth_repo_init_in_progress)
 async def parse_thoth_repo_init_message(repo_init: Dict[str, Any], openshift: OpenShift, **kwargs) -> None:

--- a/thoth/investigator/unresolved_package/investigate_unresolved_package.py
+++ b/thoth/investigator/unresolved_package/investigate_unresolved_package.py
@@ -29,7 +29,7 @@ from thoth.python import Source
 from ..metrics import scheduled_workflows
 from .. import common
 from ..configuration import Configuration
-from ..common import register_handler
+from ..common import register_handler, middletier_handlers
 
 from .metrics_unresolved_package import unresolved_package_exceptions
 from .metrics_unresolved_package import unresolved_package_in_progress
@@ -39,7 +39,7 @@ from prometheus_async.aio import track_inprogress, count_exceptions
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(unresolved_package_message.topic_name, ["v1"])
+@register_handler(unresolved_package_message.topic_name, ["v1"], middletier_handlers)
 @count_exceptions(unresolved_package_exceptions)
 @track_inprogress(unresolved_package_in_progress)
 async def parse_unresolved_package_message(

--- a/thoth/investigator/unrevsolved_package/investigate_unrevsolved_package.py
+++ b/thoth/investigator/unrevsolved_package/investigate_unrevsolved_package.py
@@ -26,7 +26,7 @@ from thoth.common import OpenShift
 from .. import common
 from ..configuration import Configuration
 from ..metrics import scheduled_workflows
-from ..common import register_handler
+from ..common import register_handler, middletier_handlers
 from .metrics_unrevsolved_package import unrevsolved_package_exceptions
 from .metrics_unrevsolved_package import unrevsolved_package_in_progress
 from .metrics_unrevsolved_package import unrevsolved_package_success
@@ -35,7 +35,7 @@ from prometheus_async.aio import track_inprogress, count_exceptions
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(unrevsolved_package_message.topic_name, ["v1"])
+@register_handler(unrevsolved_package_message.topic_name, ["v1"], middletier_handlers)
 @count_exceptions(unrevsolved_package_exceptions)
 @track_inprogress(unrevsolved_package_in_progress)
 async def parse_revsolved_package_message(unrevsolved_package: Dict[str, Any], openshift: OpenShift, **kwargs) -> None:

--- a/thoth/investigator/update_provide_source_distro/investigate_update_provide_source_distro.py
+++ b/thoth/investigator/update_provide_source_distro/investigate_update_provide_source_distro.py
@@ -23,7 +23,7 @@ import logging
 from thoth.messaging import update_provides_source_distro_message
 from thoth.storages import GraphDatabase
 
-from ..common import register_handler
+from ..common import register_handler, middletier_handlers
 
 from .metrics_update_provide_source_distro import update_provide_source_distro_exceptions
 from .metrics_update_provide_source_distro import update_provide_source_distro_success
@@ -33,7 +33,7 @@ from prometheus_async.aio import track_inprogress, count_exceptions
 _LOGGER = logging.getLogger(__name__)
 
 
-@register_handler(update_provides_source_distro_message.topic_name, ["v1"])
+@register_handler(update_provides_source_distro_message.topic_name, ["v1"], middletier_handlers)
 @count_exceptions(update_provide_source_distro_exceptions)
 @track_inprogress(update_provide_source_distro_in_progress)
 async def parse_update_provide_source_distro_message(


### PR DESCRIPTION
bottleneck due to argo workflow limit which kept user workflows in backend from getting scheduled due to middletier workflow limit

Signed-off-by: Kevin <kpostlet@redhat.com>

## Related Issues and Dependencies

fixes: #673 

## This introduces a breaking change

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

